### PR TITLE
Add detail option to note menu

### DIFF
--- a/packages/client/src/scripts/get-note-menu.ts
+++ b/packages/client/src/scripts/get-note-menu.ts
@@ -8,6 +8,7 @@ import * as os from '@/os';
 import copyToClipboard from '@/scripts/copy-to-clipboard';
 import { url } from '@/config';
 import { noteActions } from '@/store';
+import { notePage } from '@/filters/note';
 
 export function getNoteMenu(props: {
 	note: misskey.entities.Note;
@@ -173,6 +174,10 @@ export function getNoteMenu(props: {
 		});
 	}
 
+	function openDetail(): void {
+		window.open(notePage(appearNote), '_blank');
+	}
+
 	async function translate(): Promise<void> {
 		if (props.translation.value != null) return;
 		props.translating.value = true;
@@ -198,8 +203,11 @@ export function getNoteMenu(props: {
 					danger: true,
 					action: unclip,
 				}, null] : []
-			),
-			{
+			), {
+				icon: 'fas fa-external-link-alt',
+				text: i18n.ts.detailed,
+				action: openDetail,
+			}, {
 				icon: 'fas fa-copy',
 				text: i18n.ts.copyContent,
 				action: copyContent,
@@ -300,6 +308,10 @@ export function getNoteMenu(props: {
 			.filter(x => x !== undefined);
 	} else {
 		menu = [{
+			icon: 'fas fa-external-link-alt',
+			text: i18n.ts.detailed,
+			action: openDetail,
+		}, {
 			icon: 'fas fa-copy',
 			text: i18n.ts.copyContent,
 			action: copyContent,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
(Hopefully) add "detail" link to note menu, i.e. the menu shown under "..." or on right click on a note.

# Why
Currently the only way to get to a note detail page is clicking on the time listed. This is not very intuitive or discoverable from a UX point of view.

# Additional info 
I didn't test this 😅 
